### PR TITLE
Fix 403 Forbidden error when fetching data

### DIFF
--- a/api.py
+++ b/api.py
@@ -208,9 +208,13 @@ def download_self_stocks_v2(
     *,
     timeout: float = SELF_STOCK_HTTP_TIMEOUT,
 ) -> Tuple[Dict[str, Any], List[Tuple[str, str]]]:
+    headers = {
+        "User-Agent": DEFAULT_HEADERS.get("User-Agent", "hevo"),
+    }
     try:
         response = requests.get(
             f"{SELF_STOCK_V2_BASE_URL}{SELF_STOCK_V2_LIST_PATH}",
+            headers=headers,
             cookies=cookies,
             timeout=timeout,
         )


### PR DESCRIPTION
修复获取自选股数据403 Forbidden问题（接口增加了User-Agent校验导致的）
> 网络错误: 我的自选 失败: 403 Client Error: Forbidden for url: https://t.10jqka.com.cn/newcircle/group/getSelfStockWithMarket/

Fix #4 